### PR TITLE
Add executor for sync activities

### DIFF
--- a/src/demo_temporal/workflows/inference/activities.py
+++ b/src/demo_temporal/workflows/inference/activities.py
@@ -15,7 +15,7 @@ async def get_model(data: InferenceModelInput):
 
 
 @activity.defn
-async def construct_model_input(data: InferenceUserInput) -> str:
+def construct_model_input(data: InferenceUserInput) -> str:
     # also validates that the input is not empty
     if not data.raw_input and data.input_file:
         with open(data.input_file, "r", encoding="utf-8") as f:
@@ -27,17 +27,17 @@ async def construct_model_input(data: InferenceUserInput) -> str:
 
 
 @activity.defn
-async def run_inference(data: InferenceModelInput) -> list[str]:
+def run_inference(data: InferenceModelInput) -> list[str]:
     from .llm import evaluate_model
 
-    return await evaluate_model(data)
+    return evaluate_model(data)
 
 
 @activity.defn
-async def write_results(data: InferenceResultsInput) -> None:
+def write_results(data: InferenceResultsInput) -> None:
     """
     Write the inference results to a file.
     """
     from .llm import write_cif_files
 
-    await write_cif_files(data)
+    write_cif_files(data)

--- a/src/demo_temporal/workflows/inference/llm.py
+++ b/src/demo_temporal/workflows/inference/llm.py
@@ -67,7 +67,7 @@ async def download_model(model_path: str, model_url: str | None = None) -> dict:
     return {"model_path": model_path, "model_url": model_url}
 
 
-async def evaluate_model(inference_state: InferenceModelInput) -> list[str]:
+def evaluate_model(inference_state: InferenceModelInput) -> list[str]:
     """
     Evaluate the model with the given parameters.
     Adapted from https://github.com/lantunes/CrystaLLM
@@ -130,7 +130,7 @@ async def evaluate_model(inference_state: InferenceModelInput) -> list[str]:
     return generated
 
 
-async def write_cif_files(result: InferenceResultsInput) -> None:
+def write_cif_files(result: InferenceResultsInput) -> None:
     """
     Write the generated CIFs to the specified target (console or file).
     """


### PR DESCRIPTION
- Makes validation, inference, and result writing activities sync
- Specifies `ThreadPoolExecutor` for sync activities as mentioned on [temporal](https://docs.temporal.io/develop/python/python-sdk-sync-vs-async#how-to-run-synchronous-activities-on-a-worker)